### PR TITLE
chore(deps): Revert to net6.0 and update to MarkMpn.Sql4Cds.Engine 9.6.0 + Microsoft.PowerPlatform.Dataverse.Client 1.2.3

### DIFF
--- a/Rnwood.Dataverse.Data.PowerShell.FrameworkSpecific/Commands/GetDataverseConnectionCmdlet.cs
+++ b/Rnwood.Dataverse.Data.PowerShell.FrameworkSpecific/Commands/GetDataverseConnectionCmdlet.cs
@@ -23,6 +23,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using AuthenticationResult = Microsoft.Identity.Client.AuthenticationResult;
+using System.Security;
 
 
 namespace Rnwood.Dataverse.Data.PowerShell.Commands
@@ -234,7 +235,7 @@ Url + "/api/data/v9.2/");
 			Uri scope = new Uri(Url, "/.default");
 			string[] scopes = new[] { scope.ToString() };
 
-			AuthenticationResult authResult = await app.AcquireTokenByUsernamePassword(scopes, Username, Password).ExecuteAsync();
+			AuthenticationResult authResult = await app.AcquireTokenByUsernamePassword(scopes, Username, new NetworkCredential("", Password).SecurePassword).ExecuteAsync();
 
 
 			return authResult.AccessToken;

--- a/Rnwood.Dataverse.Data.PowerShell.FrameworkSpecific/Rnwood.Dataverse.Data.PowerShell.FrameworkSpecific.csproj
+++ b/Rnwood.Dataverse.Data.PowerShell.FrameworkSpecific/Rnwood.Dataverse.Data.PowerShell.FrameworkSpecific.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <AssemblyTitle>Rnwood.Dataverse.Data.PowerShell.FrameworkSpecific</AssemblyTitle>
     <Product>Rnwood.Dataverse.Data.PowerShell.FrameworkSpecific</Product>
     <Copyright>Copyright © 2023-2024</Copyright>
@@ -41,7 +41,7 @@
     <PackageReference Include="System.ServiceModel.Primitives" Version="[4.10.3]" />
     <PackageReference Include="System.ServiceModel.Http" Version="[4.10.3]" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="FakeXrmEasy.v9">
       <Version>3.4.2</Version>
     </PackageReference>

--- a/Rnwood.Dataverse.Data.PowerShell.FrameworkSpecific/Rnwood.Dataverse.Data.PowerShell.FrameworkSpecific.csproj
+++ b/Rnwood.Dataverse.Data.PowerShell.FrameworkSpecific/Rnwood.Dataverse.Data.PowerShell.FrameworkSpecific.csproj
@@ -6,6 +6,7 @@
     <Copyright>Copyright © 2023-2024</Copyright>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <NoWarn>1701;1702;NU1605</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -17,11 +18,28 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
+    <WarningsAsErrors></WarningsAsErrors>
+    <NoWarn>1701;1702;NU1605</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net462|AnyCPU'">
+    <WarningsAsErrors></WarningsAsErrors>
+    <NoWarn>1701;1702;NU1605</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
+    <WarningsAsErrors></WarningsAsErrors>
+    <NoWarn>1701;1702;NU1605</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net462|AnyCPU'">
+    <WarningsAsErrors></WarningsAsErrors>
+    <NoWarn>1701;1702;NU1605</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MarkMpn.Sql4Cds.Engine" Version="9.4.1" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.69.1" />
-    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.1.9" />
+    <PackageReference Include="MarkMpn.Sql4Cds.Engine" Version="9.6.0" />
+    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.3" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="[4.10.3]" />
+    <PackageReference Include="System.ServiceModel.Http" Version="[4.10.3]" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="FakeXrmEasy.v9">

--- a/Rnwood.Dataverse.Data.PowerShell/Rnwood.Dataverse.Data.PowerShell.psd1
+++ b/Rnwood.Dataverse.Data.PowerShell/Rnwood.Dataverse.Data.PowerShell.psd1
@@ -66,7 +66,7 @@ PrivateData = @{
 NestedModules = 
 @(if ($PSEdition -eq 'Core') {
 	@(
-		"net8.0/Rnwood.Dataverse.Data.PowerShell.FrameworkSpecific.dll",
+		"net6.0/Rnwood.Dataverse.Data.PowerShell.FrameworkSpecific.dll",
 		"Get-DataverseRecordsFolder.psm1",
 		"Set-DataverseRecordsFolder.psm1"
 	)

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -47,7 +47,7 @@ Describe "Module" {
             $modulefolder = (Get-Module -ListAvailable Rnwood.Dataverse.Data.PowerShell).ModuleBase
 
             if ($PSVersionTable.PSEdition -eq "Core") {
-                add-type -AssemblyName $modulefolder/net8.0/Microsoft.Xrm.Sdk.dll
+                add-type -AssemblyName $modulefolder/net6.0/Microsoft.Xrm.Sdk.dll
             } else {
                 add-type -AssemblyName $modulefolder/net462/Microsoft.Xrm.Sdk.dll
             }


### PR DESCRIPTION
For changelogs see #13 and #22.

Combines these PRs with the workaround for peer deps to force them to be compatible.