### PR TITLE
docs: setup better issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,69 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[BUG] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the form below to help us understand and reproduce the issue.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe the bug here...
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        Example script
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: A clear and concise description of what actually happened.
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: PowerShell version
+      description: Which PowerShell version are you running in? Please run `$PSVersionTable` in PowerShell and paste the output below.
+    validations:
+      required: true
+  - type: input
+    id: module-version
+    attributes:
+      label: Module Version
+      description: Which version of the module are you using? You can find this by running `Get-Module Rnwood.Dataverse.Data.PowerShell -ListAvailable`.
+      placeholder: e.g., 1.2.3
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here, such as error messages, stack traces, or screenshots.
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have tried the latest version of the module
+          required: true
+        - label: I have searched for similar issues and couldn't find any
+          required: true
+        - label: I have included all the information needed to reproduce the issue
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: README
+    url: https://github.com/rnwood/Rnwood.Dataverse.Data.PowerShell/blob/main/README.md
+    about: Find installation instructions and usage examples
+  - name: Documentation
+    url: https://github.com/rnwood/Rnwood.Dataverse.Data.PowerShell/tree/main/Rnwood.Dataverse.Data.PowerShell/docs
+    about: Browse detailed cmdlet documentation

--- a/.github/ISSUE_TEMPLATE/documentation-issue.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.yml
@@ -1,0 +1,57 @@
+name: Documentation Issue
+description: Report issues with documentation, examples, or help content
+title: "[DOCS] "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve our documentation! Please fill out the form below.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What documentation issue did you find?
+      placeholder: Describe the documentation issue here...
+    validations:
+      required: true
+  - type: input
+    id: location
+    attributes:
+      label: Location
+      description: Where is the issue located? (file path, URL, cmdlet name, etc.)
+      placeholder: e.g., README.md, docs/Get-DataverseRecord.md, cmdlet help
+    validations:
+      required: true
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Type of Issue
+      options:
+        - Incorrect information
+        - Missing information
+        - Unclear explanation
+        - Outdated content
+        - Broken link
+        - Code example doesn't work
+        - Formatting issue
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: current-content
+    attributes:
+      label: Current Content
+      description: What does the current documentation say?
+      placeholder: Copy the relevant text here...
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested Fix
+      description: How should it be fixed?
+      placeholder: Describe the fix or provide corrected content...
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context about the documentation issue here.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,57 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[FEATURE] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new feature! Please fill out the form below to help us understand your idea.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+      placeholder: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternative Solutions
+      description: Describe alternatives you've considered.
+      placeholder: A clear and concise description of any alternative solutions or features you've considered.
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      description: How important is this feature to you?
+      options:
+        - Nice to have
+        - Would be helpful
+        - Important for my use case
+        - Critical/blocking my work
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context or screenshots about the feature request here.
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched for similar feature requests and couldn't find any
+          required: true
+        - label: This feature would benefit other users as well
+          required: false

--- a/.github/ISSUE_TEMPLATE/question-support.yml
+++ b/.github/ISSUE_TEMPLATE/question-support.yml
@@ -1,0 +1,45 @@
+name: Question / Support
+description: Ask a question or request help
+title: "[QUESTION] "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Need help or have a question? Please fill out the form below. For general questions, consider checking our documentation first or asking in community forums.
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What is your question?
+      placeholder: Ask your question here...
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Provide context about what you're trying to do.
+      placeholder: What are you trying to accomplish? What have you tried so far?
+  - type: input
+    id: environment
+    attributes:
+      label: PowerShell version
+      description: Which PowerShell version are you running in? Please run `$PSVersionTable` in PowerShell and paste the output below.
+  - type: input
+    id: module-version
+    attributes:
+      label: Module Version
+      description: Which version of the module are you using? You can find this by running `Get-Module Rnwood.Dataverse.Data.PowerShell -ListAvailable`.
+      placeholder: e.g., 1.2.3
+  - type: textarea
+    id: code-example
+    attributes:
+      label: Code Example
+      description: If applicable, provide a code example that demonstrates your question.
+      render: powershell
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional Information
+      description: Any additional information that might help answer your question.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,26 @@
       },
       "justMyCode": false
     },
+     {
+      "name": "Debug Cmdlets: Launch pwsh (Framework)",
+      "type": "clr",
+      "request": "launch",
+      "preLaunchTask": "Build (dotnet build)",
+      "program": "powershell.exe",
+      "args": [
+        "-NoExit",
+        "-NoProfile",
+        "-File",
+        "${workspaceFolder}/test.ps1"
+      ],
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": false,
+      "console": "integratedTerminal",
+      "env": {
+        "TESTMODULEPATH": "${workspaceFolder}/Rnwood.Dataverse.Data.PowerShell/bin/Debug/netstandard2.0"
+      },
+      "justMyCode": false
+    },
     {
       "name": "Attach to pwsh (pick process)",
       "type": "coreclr",

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddAppComponents.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddAppComponents.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddChannelAccessProfilePrivileges.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddChannelAccessProfilePrivileges.md
@@ -134,4 +134,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddItemCampaign.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddItemCampaign.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddItemCampaignActivity.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddItemCampaignActivity.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddListMembersList.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddListMembersList.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddMemberList.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddMemberList.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddMembersTeam.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddMembersTeam.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddPrincipalToQueue.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddPrincipalToQueue.md
@@ -179,4 +179,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddPrivilegesRole.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddPrivilegesRole.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddRecurrence.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddRecurrence.md
@@ -179,4 +179,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddSolutionComponent.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddSolutionComponent.md
@@ -195,4 +195,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddToQueue.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddToQueue.md
@@ -210,4 +210,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddUserToRecordTeam.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAddUserToRecordTeam.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseApplyRecordCreationAndUpdateRule.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseApplyRecordCreationAndUpdateRule.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseApplyRoutingRule.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseApplyRoutingRule.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAssign.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAssign.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAutoMapEntity.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseAutoMapEntity.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseBackgroundSendEmail.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseBackgroundSendEmail.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseBook.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseBook.md
@@ -179,4 +179,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseBulkDelete.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseBulkDelete.md
@@ -240,4 +240,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseBulkDetectDuplicates.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseBulkDetectDuplicates.md
@@ -225,4 +225,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCalculateActualValueOpportunity.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCalculateActualValueOpportunity.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCalculatePrice.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCalculatePrice.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCalculateRollupField.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCalculateRollupField.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCalculateTotalTimeIncident.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCalculateTotalTimeIncident.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCancelContract.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCancelContract.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCancelSalesOrder.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCancelSalesOrder.md
@@ -179,4 +179,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCheckIncomingEmail.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCheckIncomingEmail.md
@@ -255,4 +255,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCheckPromoteEmail.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCheckPromoteEmail.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCloneAsPatch.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCloneAsPatch.md
@@ -149,4 +149,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCloneAsSolution.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCloneAsSolution.md
@@ -149,4 +149,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCloneContract.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCloneContract.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCloneMobileOfflineProfile.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCloneMobileOfflineProfile.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCloneProduct.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCloneProduct.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCloseIncident.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCloseIncident.md
@@ -180,4 +180,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCloseQuote.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCloseQuote.md
@@ -179,4 +179,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCommitAnnotationBlocksUpload.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCommitAnnotationBlocksUpload.md
@@ -195,4 +195,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCommitAttachmentBlocksUpload.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCommitAttachmentBlocksUpload.md
@@ -195,4 +195,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCommitFileBlocksUpload.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCommitFileBlocksUpload.md
@@ -164,4 +164,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCompoundUpdateDuplicateDetectionRule.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCompoundUpdateDuplicateDetectionRule.md
@@ -179,4 +179,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseConvertKitToProduct.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseConvertKitToProduct.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseConvertOwnerTeamToAccessTeam.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseConvertOwnerTeamToAccessTeam.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseConvertProductToKit.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseConvertProductToKit.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseConvertQuoteToSalesOrder.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseConvertQuoteToSalesOrder.md
@@ -210,4 +210,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseConvertSalesOrderToInvoice.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseConvertSalesOrderToInvoice.md
@@ -149,4 +149,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCopyCampaign.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCopyCampaign.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCopyCampaignResponse.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCopyCampaignResponse.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCopyDynamicListToStatic.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCopyDynamicListToStatic.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCopyMembersList.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCopyMembersList.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCopySystemForm.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCopySystemForm.md
@@ -179,4 +179,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCreateActivitiesList.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCreateActivitiesList.md
@@ -302,4 +302,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCreateException.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCreateException.md
@@ -195,4 +195,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCreateInstance.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCreateInstance.md
@@ -179,4 +179,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCreateKnowledgeArticleTranslation.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCreateKnowledgeArticleTranslation.md
@@ -149,4 +149,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCreateKnowledgeArticleVersion.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCreateKnowledgeArticleVersion.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCreatePolymorphicLookupAttribute.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCreatePolymorphicLookupAttribute.md
@@ -149,4 +149,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCreateWorkflowFromTemplate.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseCreateWorkflowFromTemplate.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeleteAndPromote.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeleteAndPromote.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeleteAndPromoteAsync.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeleteAndPromoteAsync.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeleteAuditData.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeleteAuditData.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeleteFile.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeleteFile.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeleteOpenInstances.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeleteOpenInstances.md
@@ -195,4 +195,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeleteRecordChangeHistory.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeleteRecordChangeHistory.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeleteRecordChangeHistory1.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeleteRecordChangeHistory1.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeliverImmediatePromoteEmail.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeliverImmediatePromoteEmail.md
@@ -377,4 +377,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeliverIncomingEmail.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeliverIncomingEmail.md
@@ -347,4 +347,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeliverPromoteEmail.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeliverPromoteEmail.md
@@ -347,4 +347,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeprovisionLanguage.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDeprovisionLanguage.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDistributeCampaignActivity.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDistributeCampaignActivity.md
@@ -287,4 +287,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDownloadBlock.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDownloadBlock.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDownloadReportDefinition.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDownloadReportDefinition.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDownloadSolutionExportData.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseDownloadSolutionExportData.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExecuteByIdSavedQuery.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExecuteByIdSavedQuery.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExecuteByIdUserQuery.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExecuteByIdUserQuery.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExecuteWorkflow.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExecuteWorkflow.md
@@ -149,4 +149,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExpandCalendar.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExpandCalendar.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExportFieldTranslation.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExportFieldTranslation.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExportMappingsImportMap.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExportMappingsImportMap.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExportSolution.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExportSolution.md
@@ -334,4 +334,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExportSolutionAsync.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExportSolutionAsync.md
@@ -334,4 +334,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExportTranslation.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseExportTranslation.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseFetchXmlToQueryExpression.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseFetchXmlToQueryExpression.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseFindParentResourceGroup.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseFindParentResourceGroup.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseFormatAddress.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseFormatAddress.md
@@ -179,4 +179,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseFulfillSalesOrder.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseFulfillSalesOrder.md
@@ -179,4 +179,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseFullTextSearchKnowledgeArticle.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseFullTextSearchKnowledgeArticle.md
@@ -179,4 +179,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGenerateInvoiceFromOpportunity.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGenerateInvoiceFromOpportunity.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGenerateQuoteFromOpportunity.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGenerateQuoteFromOpportunity.md
@@ -149,4 +149,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGenerateSalesOrderFromOpportunity.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGenerateSalesOrderFromOpportunity.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGenerateSharedLink.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGenerateSharedLink.md
@@ -134,4 +134,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGenerateSocialProfile.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGenerateSocialProfile.md
@@ -164,4 +164,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetAllTimeZonesWithDisplayName.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetAllTimeZonesWithDisplayName.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetAutoNumberSeed.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetAutoNumberSeed.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetAutoNumberSeed1.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetAutoNumberSeed1.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetDecryptionKey.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetDecryptionKey.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetDefaultPriceLevel.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetDefaultPriceLevel.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetDistinctValuesImportFile.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetDistinctValuesImportFile.md
@@ -164,4 +164,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetFileSasUrl.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetFileSasUrl.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetHeaderColumnsImportFile.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetHeaderColumnsImportFile.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetInvoiceProductsFromOpportunity.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetInvoiceProductsFromOpportunity.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetNextAutoNumberValue.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetNextAutoNumberValue.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetNextAutoNumberValue1.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetNextAutoNumberValue1.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetPreferredSolution.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetPreferredSolution.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetQuantityDecimal.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetQuantityDecimal.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetQuoteProductsFromOpportunity.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetQuoteProductsFromOpportunity.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetReportHistoryLimit.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetReportHistoryLimit.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetSalesOrderProductsFromOpportunity.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetSalesOrderProductsFromOpportunity.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetTimeZoneCodeByLocalizedName.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetTimeZoneCodeByLocalizedName.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetTrackingTokenEmail.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGetTrackingTokenEmail.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGrantAccess.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGrantAccess.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGrantAccessUsingSharedLink.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseGrantAccessUsingSharedLink.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImmediateBook.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImmediateBook.md
@@ -209,4 +209,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportCardTypeSchema.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportCardTypeSchema.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportFieldTranslation.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportFieldTranslation.md
@@ -140,4 +140,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportMappingsImportMap.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportMappingsImportMap.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportRecordsImport.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportRecordsImport.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportSolution.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportSolution.md
@@ -360,4 +360,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportSolutionAsync.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportSolutionAsync.md
@@ -360,4 +360,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportSolutions.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportSolutions.md
@@ -234,4 +234,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportTranslation.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportTranslation.md
@@ -155,4 +155,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportTranslationAsync.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseImportTranslationAsync.md
@@ -155,4 +155,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseIncrementKnowledgeArticleViewCount.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseIncrementKnowledgeArticleViewCount.md
@@ -164,4 +164,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInitializeAnnotationBlocksDownload.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInitializeAnnotationBlocksDownload.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInitializeAnnotationBlocksUpload.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInitializeAnnotationBlocksUpload.md
@@ -164,4 +164,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInitializeAttachmentBlocksDownload.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInitializeAttachmentBlocksDownload.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInitializeAttachmentBlocksUpload.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInitializeAttachmentBlocksUpload.md
@@ -164,4 +164,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInitializeFileBlocksDownload.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInitializeFileBlocksDownload.md
@@ -149,4 +149,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInitializeFileBlocksUpload.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInitializeFileBlocksUpload.md
@@ -149,4 +149,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInitializeFrom.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInitializeFrom.md
@@ -165,4 +165,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInitializeModernFlowFromAsyncWorkflow.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInitializeModernFlowFromAsyncWorkflow.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInstallSampleData.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInstallSampleData.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInstantiateFilters.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInstantiateFilters.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInstantiateTemplate.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseInstantiateTemplate.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseIsComponentCustomizable.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseIsComponentCustomizable.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseIsValidStateTransition.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseIsValidStateTransition.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseLocalTimeFromUtcTime.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseLocalTimeFromUtcTime.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseLockInvoicePricing.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseLockInvoicePricing.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseLockSalesOrderPricing.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseLockSalesOrderPricing.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseLoseOpportunity.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseLoseOpportunity.md
@@ -180,4 +180,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseMerge.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseMerge.md
@@ -210,4 +210,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseModifyAccess.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseModifyAccess.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseParseImport.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseParseImport.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePickFromQueue.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePickFromQueue.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePreferredSolutionUsedBy.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePreferredSolutionUsedBy.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseProcessInboundEmail.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseProcessInboundEmail.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePropagateByExpression.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePropagateByExpression.md
@@ -303,4 +303,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseProvisionLanguage.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseProvisionLanguage.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseProvisionLanguageAsync.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseProvisionLanguageAsync.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePublishAllXml.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePublishAllXml.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePublishAllXmlAsync.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePublishAllXmlAsync.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePublishDuplicateRule.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePublishDuplicateRule.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePublishProductHierarchy.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePublishProductHierarchy.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePublishTheme.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePublishTheme.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePublishXml.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataversePublishXml.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseQualifyLead.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseQualifyLead.md
@@ -240,4 +240,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseQualifyMemberList.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseQualifyMemberList.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseQueryExpressionToFetchXml.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseQueryExpressionToFetchXml.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseQueryMultipleSchedules.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseQueryMultipleSchedules.md
@@ -165,4 +165,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseQuerySchedule.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseQuerySchedule.md
@@ -165,4 +165,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseQueueUpdateRibbonClientMetadata.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseQueueUpdateRibbonClientMetadata.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseReassignObjectsOwner.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseReassignObjectsOwner.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseReassignObjectsSystemUser.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseReassignObjectsSystemUser.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRecalculate.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRecalculate.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseReleaseToQueue.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseReleaseToQueue.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveAppComponents.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveAppComponents.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveFromQueue.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveFromQueue.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveItemCampaign.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveItemCampaign.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveItemCampaignActivity.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveItemCampaignActivity.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveMemberList.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveMemberList.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveMembersTeam.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveMembersTeam.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveParent.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveParent.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemovePrivilegeRole.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemovePrivilegeRole.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveRelated.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveRelated.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveSolutionComponent.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveSolutionComponent.md
@@ -149,4 +149,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveUserFromRecordTeam.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRemoveUserFromRecordTeam.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRenewContract.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRenewContract.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRenewEntitlement.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRenewEntitlement.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseReplacePrivilegesRole.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseReplacePrivilegesRole.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseReschedule.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseReschedule.md
@@ -179,4 +179,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseResetUserFilters.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseResetUserFilters.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAadUserPrivileges.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAadUserPrivileges.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAadUserRoles.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAadUserRoles.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAadUserSetOfPrivilegesByIds.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAadUserSetOfPrivilegesByIds.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAadUserSetOfPrivilegesByNames.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAadUserSetOfPrivilegesByNames.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAbsoluteAndSiteCollectionUrl.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAbsoluteAndSiteCollectionUrl.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveActivePath.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveActivePath.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAllChildUsersSystemUser.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAllChildUsersSystemUser.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAnalyticsStoreDetails.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAnalyticsStoreDetails.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAppComponents.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAppComponents.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveApplicationRibbon.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveApplicationRibbon.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAttributeChangeHistory.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAttributeChangeHistory.md
@@ -149,4 +149,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAuditDetails.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAuditDetails.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAuditPartitionList.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAuditPartitionList.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAvailableLanguages.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveAvailableLanguages.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveBusinessHierarchyBusinessUnit.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveBusinessHierarchyBusinessUnit.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveByGroupResource.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveByGroupResource.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveByResourceResourceGroup.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveByResourceResourceGroup.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveByResourcesService.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveByResourcesService.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveByTopIncidentProductKbArticle.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveByTopIncidentProductKbArticle.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveByTopIncidentSubjectKbArticle.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveByTopIncidentSubjectKbArticle.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveChannelAccessProfilePrivileges.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveChannelAccessProfilePrivileges.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveCurrentOrganization.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveCurrentOrganization.md
@@ -119,4 +119,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveDependenciesForDelete.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveDependenciesForDelete.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveDependenciesForUninstall.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveDependenciesForUninstall.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveDependentComponents.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveDependentComponents.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveDeploymentLicenseType.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveDeploymentLicenseType.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveDeprovisionedLanguages.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveDeprovisionedLanguages.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveDuplicates.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveDuplicates.md
@@ -195,4 +195,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveEntityRibbon.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveEntityRibbon.md
@@ -134,4 +134,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveExchangeAppointments.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveExchangeAppointments.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveExchangeRate.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveExchangeRate.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveFeatureControlSetting.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveFeatureControlSetting.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveFeatureControlSettings.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveFeatureControlSettings.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveFeatureControlSettingsByNamespace.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveFeatureControlSettingsByNamespace.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveFilteredForms.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveFilteredForms.md
@@ -149,4 +149,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveFormXml.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveFormXml.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveFormattedImportJobResults.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveFormattedImportJobResults.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveInstalledLanguagePackVersion.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveInstalledLanguagePackVersion.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveInstalledLanguagePacks.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveInstalledLanguagePacks.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveLicenseInfo.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveLicenseInfo.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveLocLabels.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveLocLabels.md
@@ -149,4 +149,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveMailboxTrackingFolders.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveMailboxTrackingFolders.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveMembersBulkOperation.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveMembersBulkOperation.md
@@ -164,4 +164,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveMissingComponents.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveMissingComponents.md
@@ -140,4 +140,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveMissingDependencies.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveMissingDependencies.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveOrganizationInfo.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveOrganizationInfo.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveOrganizationResources.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveOrganizationResources.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveParentGroupsResourceGroup.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveParentGroupsResourceGroup.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveParsedDataImportFile.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveParsedDataImportFile.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrievePersonalWall.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrievePersonalWall.md
@@ -240,4 +240,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrievePrincipalAccess.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrievePrincipalAccess.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrievePrincipalAccessInfo.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrievePrincipalAccessInfo.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrievePrincipalAttributePrivileges.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrievePrincipalAttributePrivileges.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrievePrincipalSyncAttributeMappings.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrievePrincipalSyncAttributeMappings.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrievePrivilegeSet.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrievePrivilegeSet.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveProcessInstances.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveProcessInstances.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveProductProperties.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveProductProperties.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveProvisionedLanguagePackVersion.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveProvisionedLanguagePackVersion.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveProvisionedLanguages.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveProvisionedLanguages.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveRecordChangeHistory.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveRecordChangeHistory.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveRecordWall.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveRecordWall.md
@@ -255,4 +255,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveRequiredComponents.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveRequiredComponents.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveRolePrivilegesRole.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveRolePrivilegesRole.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveSharedLinks.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveSharedLinks.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveSharedPrincipalsAndAccess.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveSharedPrincipalsAndAccess.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveSubGroupsResourceGroup.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveSubGroupsResourceGroup.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveTeamPrivileges.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveTeamPrivileges.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveTimelineWallRecords.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveTimelineWallRecords.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveTotalRecordCount.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveTotalRecordCount.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUnpublished.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUnpublished.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUnpublishedMultiple.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUnpublishedMultiple.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUserLicenseInfo.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUserLicenseInfo.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUserPrivilegeByPrivilegeId.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUserPrivilegeByPrivilegeId.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUserPrivilegeByPrivilegeName.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUserPrivilegeByPrivilegeName.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUserPrivileges.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUserPrivileges.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUserQueues.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUserQueues.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUserSetOfPrivilegesByIds.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUserSetOfPrivilegesByIds.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUserSetOfPrivilegesByNames.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUserSetOfPrivilegesByNames.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUsersPrivilegesThroughTeams.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveUsersPrivilegesThroughTeams.md
@@ -149,4 +149,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveVersion.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRetrieveVersion.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRevertProduct.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRevertProduct.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseReviseQuote.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseReviseQuote.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRevokeAccess.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRevokeAccess.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRevokeSharedLink.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRevokeSharedLink.md
@@ -134,4 +134,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRollup.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRollup.md
@@ -149,4 +149,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRouteTo.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRouteTo.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSearch.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSearch.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSearchByBodyKbArticle.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSearchByBodyKbArticle.md
@@ -164,4 +164,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSearchByKeywordsKbArticle.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSearchByKeywordsKbArticle.md
@@ -164,4 +164,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSearchByTitleKbArticle.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSearchByTitleKbArticle.md
@@ -164,4 +164,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSendBulkMail.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSendBulkMail.md
@@ -179,4 +179,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSendEmail.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSendEmail.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSendEmailFromTemplate.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSendEmailFromTemplate.md
@@ -210,4 +210,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSendFax.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSendFax.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSendTemplate.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSendTemplate.md
@@ -210,4 +210,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetAutoNumberSeed.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetAutoNumberSeed.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetAutoNumberSeed1.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetAutoNumberSeed1.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetFeatureStatus.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetFeatureStatus.md
@@ -164,4 +164,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetLocLabels.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetLocLabels.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetParentBusinessUnit.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetParentBusinessUnit.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetPreferredSolution.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetPreferredSolution.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetProcess.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetProcess.md
@@ -148,4 +148,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetRelated.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetRelated.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetReportRelated.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSetReportRelated.md
@@ -164,4 +164,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseStageAndUpgrade.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseStageAndUpgrade.md
@@ -298,4 +298,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseStageAndUpgradeAsync.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseStageAndUpgradeAsync.md
@@ -298,4 +298,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseStageSolution.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseStageSolution.md
@@ -140,4 +140,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSyncBulkOperation.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSyncBulkOperation.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseTransformImport.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseTransformImport.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseTriggerServiceEndpointCheck.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseTriggerServiceEndpointCheck.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUninstallSampleData.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUninstallSampleData.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUninstallSolutionAsync.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUninstallSolutionAsync.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUnlockInvoicePricing.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUnlockInvoicePricing.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUnlockSalesOrderPricing.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUnlockSalesOrderPricing.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUnpublishDuplicateRule.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUnpublishDuplicateRule.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUpdateFeatureConfig.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUpdateFeatureConfig.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUpdateProductProperties.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUpdateProductProperties.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUpdateRibbonClientMetadata.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUpdateRibbonClientMetadata.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUpdateSolutionComponent.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUpdateSolutionComponent.md
@@ -164,4 +164,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUploadBlock.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUploadBlock.md
@@ -170,4 +170,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUtcTimeFromLocalTime.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseUtcTimeFromLocalTime.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseValidate.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseValidate.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseValidateApp.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseValidateApp.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseValidateFetchXmlExpression.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseValidateFetchXmlExpression.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseValidateRecurrenceRule.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseValidateRecurrenceRule.md
@@ -164,4 +164,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseValidateSavedQuery.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseValidateSavedQuery.md
@@ -133,4 +133,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseValidateUnpublished.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseValidateUnpublished.md
@@ -118,4 +118,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseWhoAmI.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseWhoAmI.md
@@ -103,4 +103,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseWinOpportunity.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseWinOpportunity.md
@@ -180,4 +180,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseWinQuote.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseWinQuote.md
@@ -179,4 +179,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-


### PR DESCRIPTION
This pull request adds a set of standardized GitHub issue templates to improve how users report bugs, request features, ask questions, and provide documentation feedback. It also updates the issue configuration to guide users to documentation resources.

**GitHub Issue Templates and Configuration:**

* Added four new issue templates: `bug-report.yml`, `feature-request.yml`, `question-support.yml`, and `documentation-issue.yml` to `.github/ISSUE_TEMPLATE/` for consistent and guided issue reporting. [[1]](diffhunk://#diff-7c49a365610d935ce439e3f241cd3f5d1df89a95d1a674d11ebdb1e518c7335cR1-R69) [[2]](diffhunk://#diff-a18ac139672d9f557f950ebe7df3f057ba19abe40d02ac2c81f72bcf44257b68R1-R57) [[3]](diffhunk://#diff-289e69001ea0f600fae82fba4fba58a04e3eb90d7c5e57dcfd7a2468e2fd1337R1-R45) [[4]](diffhunk://#diff-286c3c88d2594fafea4ee9f7e1003783949b0322f7c9a8a381cf059c1ee2b6dbR1-R57)
* Updated `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues and add direct links to the README and documentation for user support.