### PR TITLE
feat(get-dataverseconnection) access token auth for integration into already authenticated scenarios

### DIFF
--- a/Rnwood.Dataverse.Data.PowerShell/docs/Get-DataverseConnection.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Get-DataverseConnection.md
@@ -70,6 +70,12 @@ Get-DataverseConnection [-SetAsDefault] [-Url <Uri>] [-ManagedIdentity] [-Manage
  [-Timeout <UInt32>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
+### Authenticate with access token script block
+```
+Get-DataverseConnection [-SetAsDefault] -Url <Uri> -AccessToken <ScriptBlock> [-Timeout <UInt32>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
 ## DESCRIPTION
 
 This cmdlet establishes a connection to a Microsoft Dataverse environment which can then be used with other cmdlets in this module.
@@ -131,6 +137,13 @@ PS C:\> $c = Get-DataverseConnection -Interactive
 ```
 
 Authenticates interactively without specifying a URL. The cmdlet will automatically display a list of available Dataverse environments for the user to select from. This is useful when you have access to multiple environments and don't want to manually specify the URL.
+
+### Example 7
+```powershell
+PS C:\> $c = Get-DataverseConnection -Url https://myorg.crm11.dynamics.com -AccessToken { "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Im5PbzNaRHJ1VW1sMGhrR2ZaRjBqZWFHWW9XQT..." }
+```
+
+Gets a connection to MYORG using a script block that returns an access token. The script block is called whenever a new access token is needed. This is useful for custom authentication scenarios where you manage token acquisition externally.
 
 ## PARAMETERS
 
@@ -311,21 +324,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RequestInterceptor
-ScriptBlock to intercept and modify requests. The ScriptBlock receives the OrganizationRequest and can throw exceptions or return modified responses.
-
-```yaml
-Type: ScriptBlock
-Parameter Sets: Return a mock connection
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -SetAsDefault
 When set, this connection will be used as the default for cmdlets that don't have a connection parameter specified.
 
@@ -361,7 +359,7 @@ URL of the Dataverse environment to connect to. For example https://myorg.crm11.
 
 ```yaml
 Type: Uri
-Parameter Sets: Return a mock connection, Authenticate with client secret, Authenticate with Dataverse SDK connection string.
+Parameter Sets: Return a mock connection, Authenticate with client secret, Authenticate with Dataverse SDK connection string., Authenticate with access token script block
 Aliases:
 
 Required: True
@@ -419,6 +417,36 @@ Parameter Sets: (All)
 Aliases: proga
 
 Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RequestInterceptor
+ScriptBlock to intercept and modify requests. The ScriptBlock receives the OrganizationRequest and can throw exceptions or return modified responses.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: Return a mock connection
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AccessToken
+Script block that returns an access token string. Called whenever a new access token is needed.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: Authenticate with access token script block
+Aliases:
+
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Get-DataverseRecord.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Get-DataverseRecord.md
@@ -694,7 +694,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ### None
 ## OUTPUTS
 
-### System.Collections.Generic.IEnumerable`1[[System.Management.Automation.PSObject, System.Management.Automation, Version=7.4.6.500, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]
+### System.Collections.Generic.IEnumerable`1[[System.Management.Automation.PSObject, System.Management.Automation, Version=7.5.0.500, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]
 ## NOTES
 
 ## RELATED LINKS

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRequest.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseRequest.md
@@ -164,23 +164,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -InitialRetryDelay
-Initial delay in seconds before first retry. Subsequent retries use exponential backoff (delay doubles each time). Default is 5s.
-
-Only applies to Request and NameAndInputs parameter sets. REST API calls do not support retries.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: 5
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Method
 HTTP method to use for the REST API call (e.g., GET, POST, PATCH, DELETE).
 
@@ -259,6 +242,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ProgressAction
+See standard PS docs.
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InitialRetryDelay
+Initial delay in seconds before first retry. Subsequent retries use exponential backoff (delay doubles each time). Default is 5s.
+
+Only applies to Request and NameAndInputs parameter sets. REST API calls do not support retries.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 5
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Retries
 Number of times to retry the request on failure. Default is 0 (no retries). Each retry uses exponential backoff based on the `-InitialRetryDelay` parameter.
 
@@ -272,21 +287,6 @@ Aliases:
 Required: False
 Position: Named
 Default value: 0
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ProgressAction
-See standard PS docs.
-
-```yaml
-Type: ActionPreference
-Parameter Sets: (All)
-Aliases: proga
-
-Required: False
-Position: Named
-Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSql.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseSql.md
@@ -279,7 +279,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-### System.String
 ### System.Management.Automation.PSObject
 ## OUTPUTS
 

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseWhoAmI.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Invoke-DataverseWhoAmI.md
@@ -61,36 +61,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -InitialRetryDelay
-Initial delay in seconds before first retry. Subsequent retries use exponential backoff. Default is 5s.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Retries
-Number of times to retry on failure. Default is 0 (no retries).
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -WhatIf
 Shows what would happen if the cmdlet runs. The cmdlet is not run.
 
@@ -113,6 +83,36 @@ Accept wildcard characters: False
 Type: ActionPreference
 Parameter Sets: (All)
 Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InitialRetryDelay
+Initial delay in seconds before first retry. Subsequent retries use exponential backoff. Default is 5s.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Retries
+Number of times to retry on failure. Default is 0 (no retries).
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Remove-DataverseRecord.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Remove-DataverseRecord.md
@@ -254,21 +254,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -InitialRetryDelay
-Initial delay in seconds before first retry. Subsequent retries use exponential backoff (delay doubles each time). Default is 5s.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: 5
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -InputObject
 Record from pipeline. This allows piping in record to delete.
 
@@ -281,21 +266,6 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByValue)
-Accept wildcard characters: False
-```
-
-### -Retries
-Number of times to retry each batch item on failure. Default is 0 (no retries). Each retry uses exponential backoff based on the `-InitialRetryDelay` parameter.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: 0
-Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
@@ -341,6 +311,36 @@ Aliases: proga
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InitialRetryDelay
+Initial delay in seconds before first retry. Subsequent retries use exponential backoff (delay doubles each time). Default is 5s.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 5
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Retries
+Number of times to retry each batch item on failure. Default is 0 (no retries). Each retry uses exponential backoff based on the `-InitialRetryDelay` parameter.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Set-DataverseRecord.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Set-DataverseRecord.md
@@ -553,21 +553,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -InitialRetryDelay
-Initial delay in seconds before first retry. Subsequent retries use exponential backoff (delay doubles each time). Default is 5s.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: 5
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -InputObject
 Object containing values to be used.
 Property names must match the logical names of Dataverse fields in the specified entity and the property values are used to set the values of the Dataverse record being created/updated.
@@ -680,48 +665,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Retries
-Number of times to retry each batch item on failure. Default is 0 (no retries). Each retry uses exponential backoff based on the `-InitialRetryDelay` parameter.
-
-```yaml
-Type: Int32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: 0
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -RetrievalBatchSize
-Controls the maximum number of records to retrieve in a single query when checking for existing records. Default is 500. Specify 1 to retrieve one record at a time (original behavior).
-
-When processing multiple records through the pipeline, this parameter batches retrieval queries to significantly improve performance:
-- Records are queued until the batch size is reached or processing completes
-- All queued records are retrieved in a single optimized query using `In` operator (for ID and single-column MatchOn) or `Or` conditions (for multi-column MatchOn and intersect entities)
-- After retrieval, records are processed sequentially for create/update operations
-
-Performance impact:
-- Default (500): Retrieves up to 500 records in one query, reducing N queries to ceil(N/500)
-- Value of 1: Disables batching, retrieves one record at a time (original behavior)
-- Higher values: Better performance for large batches, but may hit Dataverse query limits
-
-This parameter only affects retrieval of existing records for comparison. To skip retrieval entirely and maximize performance, use `-CreateOnly` or `-UpdateAllColumns`.
-
-```yaml
-Type: UInt32
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: 500
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -TableName
 Logical name of entity. For many-to-many relationships, specify the intersect table name (e.g., "listcontact", "account_accounts").
 
@@ -799,6 +742,63 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -InitialRetryDelay
+Initial delay in seconds before first retry. Subsequent retries use exponential backoff (delay doubles each time). Default is 5s.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 5
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Retries
+Number of times to retry each batch item on failure. Default is 0 (no retries). Each retry uses exponential backoff based on the `-InitialRetryDelay` parameter.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RetrievalBatchSize
+Controls the maximum number of records to retrieve in a single query when checking for existing records. Default is 500. Specify 1 to retrieve one record at a time (original behavior).
+
+When processing multiple records through the pipeline, this parameter batches retrieval queries to significantly improve performance:
+- Records are queued until the batch size is reached or processing completes
+- All queued records are retrieved in a single optimized query using `In` operator (for ID and single-column MatchOn) or `Or` conditions (for multi-column MatchOn and intersect entities)
+- After retrieval, records are processed sequentially for create/update operations
+
+Performance impact:
+- Default (500): Retrieves up to 500 records in one query, reducing N queries to ceil(N/500)
+- Value of 1: Disables batching, retrieves one record at a time (original behavior)
+- Higher values: Better performance for large batches, but may hit Dataverse query limits
+
+This parameter only affects retrieval of existing records for comparison. To skip retrieval entirely and maximize performance, use `-CreateOnly` or `-UpdateAllColumns`.
+
+```yaml
+Type: UInt32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 500
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
@@ -806,8 +806,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Management.Automation.PSObject
 ### System.String
+### System.String[]
 ### System.Guid
-### System.Nullable`1[[System.Guid, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
+### System.Nullable`1[[System.Guid, System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
 ## OUTPUTS
 
 ### System.Object

--- a/tests/DefaultConnection.Tests.ps1
+++ b/tests/DefaultConnection.Tests.ps1
@@ -124,4 +124,23 @@ Describe 'Default Connection' {
         $default = Get-DataverseConnection -GetDefault
         $default | Should -Not -BeNullOrEmpty
     }
+
+    It "AccessToken parameter set accepts ScriptBlock" {
+        # Test that the AccessToken parameter accepts a ScriptBlock
+        $scriptBlock = { "fake-token" }
+        $parameters = @{
+            Url = "https://test.crm.dynamics.com"
+            AccessToken = $scriptBlock
+        }
+        
+        # Verify the cmdlet accepts the parameters without throwing during parameter binding
+        $cmdlet = Get-Command Get-DataverseConnection
+        $parameterSet = $cmdlet.ParameterSets | Where-Object { $_.Name -eq "Authenticate with access token script block" }
+        $parameterSet | Should -Not -BeNullOrEmpty
+        
+        # Verify AccessToken parameter exists and is of type ScriptBlock
+        $accessTokenParam = $parameterSet.Parameters | Where-Object { $_.Name -eq "AccessToken" }
+        $accessTokenParam | Should -Not -BeNullOrEmpty
+        $accessTokenParam.ParameterType | Should -Be ([System.Management.Automation.ScriptBlock])
+    }
 }


### PR DESCRIPTION
This pull request introduces a new authentication option for the `Get-DataverseConnection` PowerShell cmdlet, allowing users to provide a custom script block for access token acquisition.
### New authentication method for Dataverse connections

* Added support for authenticating with a user-provided access token script block via the new `PARAMSET_ACCESSTOKEN` parameter set in `GetDataverseConnectionCmdlet`. This includes a new `AccessToken` parameter and logic to invoke the script block when a token is needed. (`Rnwood.Dataverse.Data.PowerShell.Cmdlets/Commands/GetDataverseConnectionCmdlet.cs`) [[1]](diffhunk://#diff-eca22ec336429f18183cad03509cc58435ea906575884ae9c48705fbcc365730R56) [[2]](diffhunk://#diff-eca22ec336429f18183cad03509cc58435ea906575884ae9c48705fbcc365730R105) [[3]](diffhunk://#diff-eca22ec336429f18183cad03509cc58435ea906575884ae9c48705fbcc365730R164-R169) [[4]](diffhunk://#diff-eca22ec336429f18183cad03509cc58435ea906575884ae9c48705fbcc365730R405-R408) [[5]](diffhunk://#diff-eca22ec336429f18183cad03509cc58435ea906575884ae9c48705fbcc365730R632-R644)
* Updated documentation for `Get-DataverseConnection` to describe the new authentication option, provide an example usage, and document the new `AccessToken` parameter. (`Rnwood.Dataverse.Data.PowerShell/docs/Get-DataverseConnection.md`) [[1]](diffhunk://#diff-4b7dab0c1f841cbcb1db496ff188084c0f1a9d35e06f331aefee7bd587df290dR73-R78) [[2]](diffhunk://#diff-4b7dab0c1f841cbcb1db496ff188084c0f1a9d35e06f331aefee7bd587df290dR141-R147) [[3]](diffhunk://#diff-4b7dab0c1f841cbcb1db496ff188084c0f1a9d35e06f331aefee7bd587df290dR426-R455)
