### PR TITLE
docs: ensure stable property sort order to reduce noisy diffs in cmdlets docs

### DIFF
--- a/Rnwood.Dataverse.Data.PowerShell/updatehelp.ps1
+++ b/Rnwood.Dataverse.Data.PowerShell/updatehelp.ps1
@@ -68,7 +68,7 @@ if (Test-Path $stampFile) {
 # Ensure output directory exists
 if (-not (Test-Path $OutDir)) { New-Item -ItemType Directory -Path $OutDir -Force | Out-Null }
 
-update-markdownhelpmodule -path $projectdir/docs -UpdateInputOutput
+update-markdownhelpmodule -path $projectdir/docs -UpdateInputOutput -AlphabeticParamsOrder -RefreshModulePage
 
 # After successful update, write/update the stamp so future runs can be skipped
 $now = (Get-Date).ToUniversalTime().ToString("o")


### PR DESCRIPTION
This pull request makes a small but important enhancement to the PowerShell script responsible for updating markdown help documentation. The main change is the addition of new options to the `update-markdownhelpmodule` command to improve the organization and freshness of the generated documentation.

* Documentation update improvements:
  * `update-markdownhelpmodule` is now called with the `-AlphabeticParamsOrder` option to ensure parameters are listed alphabetically, and the `-RefreshModulePage` option to refresh the module page during documentation generation in `updatehelp.ps1`.