### PR TITLE
fix(import-dataverseimport): connection ref not set when solution not…

### DIFF
--- a/Rnwood.Dataverse.Data.PowerShell.Cmdlets/Commands/ImportDataverseSolutionCmdlet.cs
+++ b/Rnwood.Dataverse.Data.PowerShell.Cmdlets/Commands/ImportDataverseSolutionCmdlet.cs
@@ -1566,7 +1566,7 @@ namespace Rnwood.Dataverse.Data.PowerShell.Commands
                     Conditions =
                     {
                         new ConditionExpression("solutionid", ConditionOperator.Equal, solutionId),
-                        new ConditionExpression("componenttype", ConditionOperator.In, new object[] { 380, 635 }) // 380 = Environment Variable Definition, 635 = Connection Reference
+                        new ConditionExpression("componenttype", ConditionOperator.In, new object[] { 380, 10091 }) // 380 = Environment Variable Definition, 10091 = Connection Reference
                     }
                 }
             };


### PR DESCRIPTION
This pull request makes a small but important update to the logic for checking and updating solution components in the `ImportDataverseSolutionCmdlet`. The change updates the value used to identify connection references in the `componenttype` filter when setting CRs if solution did not require importing (this ensures CR values get updated in this case).

* Changed the `componenttype` value for Connection Reference from `635` to `10091` in the condition expression within `CheckAndUpdateSolutionComponents`, ensuring correct identification of connection references.