### PR TITLE
feat: get-dataverseenvironment to list other environments accessible by current connection's auth or accesstoken

### DIFF
--- a/Rnwood.Dataverse.Data.PowerShell.Cmdlets/Commands/GetDataverseEnvironmentCmdlet.cs
+++ b/Rnwood.Dataverse.Data.PowerShell.Cmdlets/Commands/GetDataverseEnvironmentCmdlet.cs
@@ -1,0 +1,225 @@
+using Microsoft.PowerPlatform.Dataverse.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Threading;
+using System.Threading.Tasks;
+using OrganizationDetail = Microsoft.Xrm.Sdk.Discovery.OrganizationDetail;
+
+namespace Rnwood.Dataverse.Data.PowerShell.Commands
+{
+    /// <summary>
+    /// Lists all Dataverse environments accessible to the authenticated user.
+    /// </summary>
+    [Cmdlet(VerbsCommon.Get, "DataverseEnvironment")]
+    [OutputType(typeof(OrganizationDetail))]
+    public class GetDataverseEnvironmentCmdlet : PSCmdlet
+    {
+        private const string PARAMSET_ACCESSTOKEN = "With access token";
+        private const string PARAMSET_CONNECTION = "With connection";
+
+        /// <summary>
+        /// Gets or sets the script block to provide access tokens.
+        /// </summary>
+        [Parameter(Mandatory = true, ParameterSetName = PARAMSET_ACCESSTOKEN, HelpMessage = "Script block that returns an access token string. Called with the resource URL as a parameter.")]
+        public ScriptBlock AccessToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the connection to use for discovering environments.
+        /// </summary>
+        [Parameter(Mandatory = false, ParameterSetName = PARAMSET_CONNECTION, HelpMessage = "Connection to use for discovering environments. If not specified, the default connection is used.")]
+        public ServiceClient Connection { get; set; }
+
+        /// <summary>
+        /// Gets or sets the friendly name filter. Supports wildcards.
+        /// </summary>
+        [Parameter(Mandatory = false, HelpMessage = "Filter environments by friendly name. Supports wildcards (* and ?).")]
+        [SupportsWildcards]
+        public string FriendlyName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the geo/region filter.
+        /// </summary>
+        [Parameter(Mandatory = false, HelpMessage = "Filter environments by geographic region (e.g., NA, EMEA, APAC).")]
+        public string Geo { get; set; }
+
+        /// <summary>
+        /// Gets or sets the organization type filter.
+        /// </summary>
+        [Parameter(Mandatory = false, HelpMessage = "Filter environments by organization type.")]
+        public Microsoft.Xrm.Sdk.Organization.OrganizationType? OrganizationType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timeout for the discovery operation in seconds.
+        /// </summary>
+        [Parameter(Mandatory = false, HelpMessage = "Timeout for the discovery operation in seconds. Defaults to 5 minutes.")]
+        public uint Timeout { get; set; } = 5 * 60;
+
+        // Cancellation token source that is cancelled when the user hits Ctrl+C (StopProcessing)
+        private CancellationTokenSource _userCancellationCts;
+
+        /// <summary>
+        /// Initializes the cmdlet processing.
+        /// </summary>
+        protected override void BeginProcessing()
+        {
+            base.BeginProcessing();
+            // initialize cancellation token source for this pipeline invocation
+            _userCancellationCts = new CancellationTokenSource();
+        }
+
+        /// <summary>
+        /// Called when the user cancels the cmdlet.
+        /// </summary>
+        protected override void StopProcessing()
+        {
+            // Called when user presses Ctrl+C. Signal cancellation to any ongoing operations.
+            try
+            {
+                _userCancellationCts?.Cancel();
+            }
+            catch { }
+            base.StopProcessing();
+        }
+
+        /// <summary>
+        /// Completes cmdlet processing.
+        /// </summary>
+        protected override void EndProcessing()
+        {
+            base.EndProcessing();
+            _userCancellationCts?.Dispose();
+            _userCancellationCts = null;
+        }
+
+        private CancellationTokenSource CreateLinkedCts(TimeSpan timeout)
+        {
+            var timeoutCts = new CancellationTokenSource(timeout);
+            return CancellationTokenSource.CreateLinkedTokenSource(_userCancellationCts?.Token ?? CancellationToken.None, timeoutCts.Token);
+        }
+
+        /// <summary>
+        /// Processes the cmdlet request.
+        /// </summary>
+        protected override void ProcessRecord()
+        {
+            try
+            {
+                base.ProcessRecord();
+
+                Func<string, Task<string>> tokenProvider;
+
+                if (ParameterSetName == PARAMSET_ACCESSTOKEN)
+                {
+                    // Use the provided AccessToken script block
+                    tokenProvider = GetTokenWithScriptBlock;
+                }
+                else
+                {
+                    // Get connection (use default if not specified)
+                    var connection = Connection ?? DefaultConnectionManager.DefaultConnection;
+                    if (connection == null)
+                    {
+                        ThrowTerminatingError(new ErrorRecord(
+                            new InvalidOperationException("No connection specified and no default connection is set. Use Get-DataverseConnection with -SetAsDefault or provide a -Connection parameter."),
+                            "NoConnection",
+                            ErrorCategory.InvalidOperation,
+                            null));
+                        return;
+                    }
+
+                    // Extract token provider from connection if it's a ServiceClientWithTokenProvider
+                    if (connection is ServiceClientWithTokenProvider serviceClientWithToken)
+                    {
+                        tokenProvider = serviceClientWithToken.TokenProviderFunction;
+                    }
+                    else
+                    {
+                        ThrowTerminatingError(new ErrorRecord(
+                            new InvalidOperationException("The provided connection does not support environment discovery. Please use Get-DataverseEnvironment with -AccessToken parameter instead, or create a connection using one of the authentication methods that supports token providers (Interactive, DeviceCode, ClientSecret, ClientCertificate, etc.)."),
+                            "UnsupportedConnection",
+                            ErrorCategory.InvalidOperation,
+                            connection));
+                        return;
+                    }
+                }
+
+                // Discover environments
+                using (var cts = CreateLinkedCts(TimeSpan.FromSeconds(Timeout)))
+                {
+                    var orgDetails = ServiceClient.DiscoverOnlineOrganizationsAsync(
+                        tokenProvider,
+                        new Uri("https://globaldisco.crm.dynamics.com"),
+                        null,
+                        null,
+                        cts.Token).GetAwaiter().GetResult();
+
+                    if (orgDetails == null || orgDetails.Count == 0)
+                    {
+                        WriteVerbose("No Dataverse environments found for this user.");
+                        return;
+                    }
+
+                    // Apply filters
+                    IEnumerable<OrganizationDetail> filteredOrgs = orgDetails;
+
+                    // Filter by FriendlyName with wildcard support
+                    if (!string.IsNullOrEmpty(FriendlyName))
+                    {
+                        WildcardPattern pattern = new WildcardPattern(FriendlyName, WildcardOptions.IgnoreCase);
+                        filteredOrgs = filteredOrgs.Where(org => pattern.IsMatch(org.FriendlyName));
+                    }
+
+                    // Filter by Geo
+                    if (!string.IsNullOrEmpty(Geo))
+                    {
+                        filteredOrgs = filteredOrgs.Where(org => 
+                            string.Equals(org.Geo, Geo, StringComparison.OrdinalIgnoreCase));
+                    }
+
+                    // Filter by OrganizationType
+                    if (OrganizationType.HasValue)
+                    {
+                        filteredOrgs = filteredOrgs.Where(org => org.OrganizationType == OrganizationType.Value);
+                    }
+
+                    // Write each environment to the pipeline
+                    foreach (var org in filteredOrgs)
+                    {
+                        WriteObject(org);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                // If cancellation was requested, throw a terminating PipelineStoppedException so PowerShell treats this as an interrupted operation
+                if (e is OperationCanceledException || e is TaskCanceledException || (_userCancellationCts != null && _userCancellationCts.IsCancellationRequested))
+                {
+                    ThrowTerminatingError(new ErrorRecord(new PipelineStoppedException(), "OperationStopped", ErrorCategory.OperationStopped, null));
+                }
+
+                // If it's already a PipelineStoppedException (from ThrowTerminatingError), rethrow it
+                if (e is PipelineStoppedException)
+                {
+                    throw;
+                }
+
+                WriteError(new ErrorRecord(e, "dataverse-failed-discovery", ErrorCategory.ConnectionError, null) { ErrorDetails = new ErrorDetails($"Failed to discover Dataverse environments: {e.Message}") });
+            }
+        }
+
+        private async Task<string> GetTokenWithScriptBlock(string url)
+        {
+            using (var cts = CreateLinkedCts(TimeSpan.FromSeconds(Timeout)))
+            {
+                var results = await Task.Run(() => AccessToken.Invoke(url), cts.Token);
+                if (results.Count == 0)
+                {
+                    throw new InvalidOperationException("AccessToken script block did not return a value.");
+                }
+                return results[0].BaseObject.ToString();
+            }
+        }
+    }
+}

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Get-DataverseEnvironment.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Get-DataverseEnvironment.md
@@ -1,0 +1,286 @@
+---
+external help file: Rnwood.Dataverse.Data.PowerShell.Cmdlets.dll-Help.xml
+Module Name: Rnwood.Dataverse.Data.PowerShell
+online version:
+schema: 2.0.0
+---
+
+# Get-DataverseEnvironment
+
+## SYNOPSIS
+Lists Dataverse environments accessible to the authenticated user.
+
+## SYNTAX
+
+### With access token
+```
+Get-DataverseEnvironment -AccessToken <ScriptBlock> [-FriendlyName <String>] [-Geo <String>]
+ [-OrganizationType <OrganizationType>] [-Timeout <UInt32>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
+```
+
+### With connection
+```
+Get-DataverseEnvironment [-Connection <ServiceClient>] [-FriendlyName <String>] [-Geo <String>]
+ [-OrganizationType <OrganizationType>] [-Timeout <UInt32>] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+The `Get-DataverseEnvironment` cmdlet discovers and lists Microsoft Dataverse environments that the authenticated user has access to. This cmdlet uses the Global Discovery Service to enumerate available environments across all regions.
+
+The cmdlet supports filtering by friendly name (with wildcards), geographic region, and organization type to help you quickly find specific environments.
+
+The cmdlet can work in two modes:
+1. Using an existing connection (default) - extracts the authentication from a connection object
+2. Using a custom access token provider - allows you to supply your own authentication logic
+
+## EXAMPLES
+
+### Example 1: List all environments using the default connection
+```powershell
+Get-DataverseEnvironment
+```
+
+This command lists all Dataverse environments accessible using the default connection. You must have previously set a default connection using `Get-DataverseConnection -SetAsDefault`.
+
+### Example 2: List environments using a specific connection
+```powershell
+$conn = Get-DataverseConnection -Interactive -SetAsDefault
+Get-DataverseEnvironment -Connection $conn
+```
+
+This command creates a connection with interactive authentication and then lists all accessible environments using that connection.
+
+### Example 3: Filter environments by friendly name with wildcards
+```powershell
+Get-DataverseEnvironment -FriendlyName "Contoso*"
+```
+
+This command lists all environments whose friendly name starts with "Contoso". The FriendlyName parameter supports wildcards (* and ?).
+
+### Example 4: Filter environments by geographic region
+```powershell
+Get-DataverseEnvironment -Geo "NA"
+```
+
+This command lists all environments in the North America (NA) region. Common geo values include NA (North America), EMEA (Europe/Middle East/Africa), APAC (Asia Pacific), and others.
+
+### Example 5: Filter by multiple criteria
+```powershell
+Get-DataverseEnvironment -FriendlyName "*Production*" -Geo "NA" -OrganizationType Production
+```
+
+This command lists all production environments in North America with "Production" in their friendly name.
+
+### Example 6: List environments and select one interactively
+```powershell
+$envs = Get-DataverseEnvironment
+$envs | Format-Table FriendlyName, UniqueName, Geo, @{Name="WebAppUrl"; Expression={$_.Endpoints["WebApplication"]}}
+
+# Connect to a specific environment
+$selectedEnv = $envs | Where-Object { $_.UniqueName -eq "myorg" } | Select-Object -First 1
+$url = $selectedEnv.Endpoints["WebApplication"]
+$conn = Get-DataverseConnection -Interactive -Url $url
+```
+
+This example retrieves all environments, displays them in a table, and then connects to a specific environment by its unique name.
+
+### Example 7: List environments using a custom access token provider
+```powershell
+$tokenProvider = {
+    param($url)
+    # Custom logic to get an access token for the given URL
+    # For example, using Azure CLI:
+    $scope = "$url/.default"
+    $token = az account get-access-token --resource $url --query accessToken -o tsv
+    return $token
+}
+
+Get-DataverseEnvironment -AccessToken $tokenProvider
+```
+
+This example uses a custom script block to provide access tokens. The script block receives the resource URL as a parameter and must return an access token string.
+
+### Example 8: Export filtered environment list to CSV
+```powershell
+Get-DataverseEnvironment -Geo "NA" | 
+    Select-Object FriendlyName, UniqueName, OrganizationId, UrlName, Geo, OrganizationType,
+        @{Name="WebAppUrl"; Expression={$_.Endpoints["WebApplication"]}},
+        @{Name="ApiUrl"; Expression={$_.Endpoints["OrganizationService"]}} |
+    Export-Csv -Path "na-dataverse-environments.csv" -NoTypeInformation
+```
+
+This example exports all North America environment details to a CSV file for documentation or reporting purposes.
+
+### Example 9: Find a specific environment by name
+```powershell
+$env = Get-DataverseEnvironment -FriendlyName "My Dev Environment"
+if ($env) {
+    $url = $env.Endpoints["WebApplication"]
+    Write-Host "Found environment at: $url"
+}
+```
+
+This example searches for a specific environment by its exact friendly name.
+
+## PARAMETERS
+
+### -AccessToken
+Script block that returns an access token string. The script block receives the resource URL as a parameter and must return a valid access token for that resource.
+
+This parameter is useful when you want to use a custom authentication method or integrate with external token providers.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: With access token
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Connection
+Connection to use for discovering environments. If not specified, the default connection is used.
+
+The connection must have been created using an authentication method that supports token providers (Interactive, DeviceCode, ClientSecret, ClientCertificate, DefaultAzureCredential, ManagedIdentity, or AccessToken). Connections created with ConnectionString are not supported.
+
+```yaml
+Type: ServiceClient
+Parameter Sets: With connection
+Aliases:
+
+Required: False
+Position: Named
+Default value: None (uses default connection)
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FriendlyName
+Filter environments by friendly name. Supports wildcards (* and ?).
+
+Use this parameter to find environments with specific names or name patterns. For example:
+- "Contoso Production" - exact match
+- "Contoso*" - starts with Contoso
+- "*Dev*" - contains Dev
+- "Test?" - Test followed by any single character
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -Geo
+Filter environments by geographic region.
+
+Common values include:
+- NA - North America
+- EMEA - Europe, Middle East, and Africa
+- APAC - Asia Pacific
+- SAM - South America
+- CAN - Canada
+- EUR - Europe
+- FRA - France
+- GER - Germany
+- IND - India
+- JPN - Japan
+- OCE - Oceania
+- UK - United Kingdom
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OrganizationType
+Filter environments by organization type.
+
+Valid values are:
+- Production - Production environments
+- Sandbox - Sandbox/non-production environments
+- Trial - Trial environments
+- Developer - Developer environments
+- Support - Microsoft support environments
+
+```yaml
+Type: OrganizationType
+Parameter Sets: (All)
+Aliases:
+Accepted values: Customer, Monitoring, Support, BackEnd, Secondary, CustomerTest, CustomerFreeTest, CustomerPreview, Placeholder, TestDrive, MsftInvestigation, EmailTrial, Default, Developer, Trial, Teams, Platform
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Timeout
+Timeout for the discovery operation in seconds. Defaults to 5 minutes (300 seconds).
+
+```yaml
+Type: UInt32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: 300
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### Microsoft.Xrm.Sdk.Discovery.OrganizationDetail
+
+## NOTES
+- This cmdlet requires an active internet connection to communicate with the Global Discovery Service.
+- The authenticated user must have access to at least one Dataverse environment to receive results.
+- Environment discovery works across all geographic regions automatically.
+- The cmdlet uses the Global Discovery Service endpoint at https://globaldisco.crm.dynamics.com.
+- Filters are applied after all environments are retrieved, so filtering does not improve performance for large environment lists.
+
+## RELATED LINKS
+
+[Get-DataverseConnection](Get-DataverseConnection.md)

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Rnwood.Dataverse.Data.PowerShell.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Rnwood.Dataverse.Data.PowerShell.md
@@ -57,6 +57,9 @@ Retrieves entity key (alternate key) metadata for a Dataverse table.
 ### [Get-DataverseEntityMetadata](Get-DataverseEntityMetadata.md)
 Retrieves entity (table) metadata from Dataverse.
 
+### [Get-DataverseEnvironment](Get-DataverseEnvironment.md)
+Lists Dataverse environments accessible to the authenticated user.
+
 ### [Get-DataverseEnvironmentVariableDefinition](Get-DataverseEnvironmentVariableDefinition.md)
 Gets environment variable definitions from Dataverse.
 

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Set-DataverseConnectionReference.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Set-DataverseConnectionReference.md
@@ -21,8 +21,8 @@ Set-DataverseConnectionReference [-ConnectionReferenceLogicalName] <String> [-Co
 
 ### Multiple
 ```
-Set-DataverseConnectionReference -ConnectionReferences <Hashtable> [-SolutionUniqueName <String>] [-Connection <ServiceClient>]
- [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Set-DataverseConnectionReference -ConnectionReferences <Hashtable> [-SolutionUniqueName <String>]
+ [-Connection <ServiceClient>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -33,7 +33,6 @@ The single parameter set will create a connection reference if it does not exist
 The multiple parameter set only updates existing connection references if they are found. The keys in the hastable are the logical names of the connection references to update, and the values are the connection IDs to set.
 When using the multiple parameter set, connector names can be used as keys for fallback matching. If a key does not match any connection reference logical name, the cmdlet will query all existing connection references to get their connector IDs and check if the key matches a connector name. All connection references using that connector will be mapped to the specified connection ID.
 Specify the -SolutionUniqueName parameter to limit the search for connection references to those included in a specific solution.
-
 
 ## EXAMPLES
 
@@ -276,6 +275,21 @@ Accept wildcard characters: False
 Type: ActionPreference
 Parameter Sets: (All)
 Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SolutionUniqueName
+Solution unique name to filter connection references by. When specified, only connection references that are components of this solution will be processed.
+
+```yaml
+Type: String
+Parameter Sets: Multiple
+Aliases:
 
 Required: False
 Position: Named

--- a/Rnwood.Dataverse.Data.PowerShell/docs/Set-DataverseForm.md
+++ b/Rnwood.Dataverse.Data.PowerShell/docs/Set-DataverseForm.md
@@ -16200,3 +16200,399 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+
+```yaml
+Type: FormType
+Parameter Sets: Update, UpdateWithXml
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+```yaml
+Type: FormType
+Parameter Sets: Create, CreateWithXml
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FormXmlContent
+Complete FormXml content
+
+```yaml
+Type: String
+Parameter Sets: UpdateWithXml, CreateWithXml
+Aliases: FormXml, Xml
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+ID of the form to update
+
+```yaml
+Type: Guid
+Parameter Sets: Update, UpdateWithXml
+Aliases: formid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -IsActive
+Whether the form is active (default: true)
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsDefault
+Whether this form is the default form for the entity
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Name of the form
+
+```yaml
+Type: String
+Parameter Sets: Update, UpdateWithXml
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+```yaml
+Type: String
+Parameter Sets: Create, CreateWithXml
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+Return the form ID after creation/update
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Publish
+Publish the form after creation/update
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+
+```yaml
+Type: FormType
+Parameter Sets: Update, UpdateWithXml
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+```yaml
+Type: FormType
+Parameter Sets: Create, CreateWithXml
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FormXmlContent
+Complete FormXml content
+
+```yaml
+Type: String
+Parameter Sets: UpdateWithXml, CreateWithXml
+Aliases: FormXml, Xml
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+ID of the form to update
+
+```yaml
+Type: Guid
+Parameter Sets: Update, UpdateWithXml
+Aliases: formid
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -IsActive
+Whether the form is active (default: true)
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsDefault
+Whether this form is the default form for the entity
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Name of the form
+
+```yaml
+Type: String
+Parameter Sets: Update, UpdateWithXml
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+```yaml
+Type: String
+Parameter Sets: Create, CreateWithXml
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+Return the form ID after creation/update
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Publish
+Publish the form after creation/update
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS


### PR DESCRIPTION
This pull request introduces a new PowerShell cmdlet, `Get-DataverseEnvironment`, to the `Rnwood.Dataverse.Data.PowerShell` module. The cmdlet allows users to discover and list Microsoft Dataverse environments accessible to the authenticated user, with support for various filtering options and authentication modes. The documentation has also been updated to include detailed usage instructions and examples for this new cmdlet, as well as minor improvements to the documentation for existing cmdlets.

**New cmdlet: Get-DataverseEnvironment**

* Added the `GetDataverseEnvironmentCmdlet` class in `GetDataverseEnvironmentCmdlet.cs`, implementing a PowerShell cmdlet that lists accessible Dataverse environments. The cmdlet supports filtering by friendly name (with wildcards), geographic region, and organization type, and can authenticate via either a provided access token script block or a connection object. It includes robust error handling, cancellation support, and timeout configuration.
