### PR TITLE
test: Reenable basic e2e Module tests

### DIFF
--- a/e2e-tests/Module.Tests.ps1
+++ b/e2e-tests/Module.Tests.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = "Stop"
 
-Describe "Module" -Skip {
+Describe "Module" {
 
     BeforeAll {
 


### PR DESCRIPTION
This pull request makes a small change to the test suite by enabling the execution of the `Module` test group, which was previously skipped. This will ensure that the tests within this group are now run as part of the end-to-end test process.