### PR TITLE
test: Update PowerShell versions used in tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            powershell_version: "7.4.13"
+            powershell_version: "7.4.14"
             dotnet_tfm: "net8.0"
             test_set: e2e-minimal
           - os: windows-latest
-            powershell_version: "7.4.13"
+            powershell_version: "7.4.14"
             dotnet_tfm: "net8.0"
             test_set: e2e-full
           - os: windows-latest
@@ -32,20 +32,20 @@ jobs:
             dotnet_tfm: "net462"
             test_set: e2e-minimal
           - os: ubuntu-latest
-            powershell_version: "7.6.0-rc.1"
+            powershell_version: "7.6.0"
             dotnet_tfm: "net10.0"
             test_set: e2e-minimal
           - os: windows-latest
-            powershell_version: "7.6.0-rc.1"
+            powershell_version: "7.6.0"
             dotnet_tfm: "net10.0"
             test_set: e2e-minimal
           - os: ubuntu-latest
-            powershell_version: "7.5.4"
+            powershell_version: "7.5.5"
             dotnet_tfm: "net9.0"
             test_set: e2e-minimal
           # Infrastructure tests + E2E full (all tests)
           - os: windows-latest
-            powershell_version: "7.5.4"
+            powershell_version: "7.5.5"
             dotnet_tfm: "net9.0"
             test_set: e2e-minimal
     


### PR DESCRIPTION
This pull request updates the PowerShell versions used in the GitHub Actions workflow matrix for end-to-end tests. The main goal is to keep the workflow up-to-date with the latest stable PowerShell releases and remove references to release candidates.

**CI/CD workflow updates:**

* Updated `powershell_version` in `.github/workflows/publish.yml` for all relevant matrix entries:
  - Bumped from `7.4.13` to `7.4.14`
  - Bumped from `7.6.0-rc.1` (release candidate) to stable `7.6.0`
  - Bumped from `7.5.4` to `7.5.5`