### PR TITLE
ci: improve security posture of e2e cleanup job

### DIFF
--- a/.github/workflows/nightly-cleanup.yml
+++ b/.github/workflows/nightly-cleanup.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:  # Allow manual trigger
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rnwood/Rnwood.Dataverse.Data.PowerShell/security/code-scanning/7](https://github.com/rnwood/Rnwood.Dataverse.Data.PowerShell/security/code-scanning/7)

Add an explicit `permissions` block to the workflow (root level) so all jobs inherit least-privilege access. For this workflow, the minimum needed is:

- `contents: read` (for `actions/checkout`)
- `issues: write` (for `github.rest.issues.create` in the failure notification step)

Best single fix without changing behavior: insert `permissions` between the `on:` block and `jobs:` block in `.github/workflows/nightly-cleanup.yml`. No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
